### PR TITLE
Prevent invalid group notifications before data load

### DIFF
--- a/view/components/Notification/NotImplemented/NotImplemented.tsx
+++ b/view/components/Notification/NotImplemented/NotImplemented.tsx
@@ -1,4 +1,5 @@
 import { useLogoStore } from '@/stores/useLogoStore';
+import { useSelectedMemberStore } from '@/stores/useSelectedMemberStore';
 import { Notification, Overlay, Text, Transition } from '@mantine/core';
 
 import { useEffect, useState } from 'react';
@@ -9,14 +10,22 @@ export function NotImplemented() {
   const [opened, setOpened] = useState(false);
 
   const current = useLogoStore((state) => state.current);
+  const isLoading = useSelectedMemberStore((state) => state.isLoading);
+  const allMembers = useSelectedMemberStore((state) => state.allMembers);
 
   useEffect(() => {
+    // 初期読み込み中または最初のデータ読み込み前は通知を表示しない
+    if (isLoading || allMembers.length === 0) {
+      setOpened(false);
+      return;
+    }
+
     if (current.name === 'nogizaka') {
       setOpened(true);
     } else if (current.name === 'hinatazaka' || current.name === 'sakurazaka') {
       setOpened(false);
     }
-  }, [current]);
+  }, [current, isLoading, allMembers.length]);
 
   const onClose = () => {
     setOpened(false);


### PR DESCRIPTION
Prevent premature "unimplemented group" notifications during initial data loading.

---
[Slack Thread](https://aobaiwaki.slack.com/archives/C09E9911NMQ/p1757903923120109?thread_ts=1757903923.120109&cid=C09E9911NMQ)

<a href="https://cursor.com/background-agent?bcId=bc-ef2bd754-02ad-4898-a97b-c8b27cbbd1dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef2bd754-02ad-4898-a97b-c8b27cbbd1dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

