### PR TITLE
Fix member display after data fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 .df-credentials.json
+
+# pnpm build
+sw.js
+workbox-*.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
   "git.replaceTagsWhenPull": true,
   "githubIssues.alwaysPromptForNewIssueRepo": true,
   "cSpell.words": [
+    "Hinatazaka",
     "sakamichipenlightquiz",
     "sakurazaka",
     "vulns"

--- a/k8s/manifests/dev/deployment.yml
+++ b/k8s/manifests/dev/deployment.yml
@@ -16,7 +16,7 @@ spec:
         - name: gcr-pull-secret
       containers:
         - name: penlight
-          image: gcr.io/my-docker-471807/penlight/prod-view-penlight:dev-916836ef
+          image: gcr.io/my-docker-471807/penlight/prod-view-penlight:dev-309bc952
           volumeMounts:
             - name: gcp-sa-volume
               mountPath: /app/secret

--- a/view/components/Header/FilterButton/FilterButton.tsx
+++ b/view/components/Header/FilterButton/FilterButton.tsx
@@ -36,7 +36,6 @@ export function FilterButton() {
       .filter(([, checked]) => checked)
       .map(([label]) => label);
 
-
     const selectedGenerations: Generation[] = []
     let graduatedFilter = false
 
@@ -60,7 +59,10 @@ export function FilterButton() {
       filterObj.gen = selectedGenerations
     }
 
-    filterObj.graduated = graduatedFilter
+    // 卒業生フィルターは明示的にチェックされた場合のみ設定
+    if (graduatedFilter) {
+      filterObj.graduated = graduatedFilter
+    }
 
     useSelectedMemberStore.getState().setFilters(filterObj)
   }, [checkedFilters])

--- a/view/components/Helper/ModeIconWrapper/initialMemberLoader.tsx
+++ b/view/components/Helper/ModeIconWrapper/initialMemberLoader.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 import { useSelectedMemberStore } from '@/stores/useSelectedMemberStore';
+import { useFilterStore } from '@/stores/useFilterStore';
+import { hinatazakaFilters } from '@/consts/hinatazakaFilters';
 
 export const InitialLoader = () => {
   const selectedGroup = useSelectedMemberStore((state) => state.selectedGroup);
@@ -9,6 +11,11 @@ export const InitialLoader = () => {
   const setGroup = useSelectedMemberStore((state) => state.setGroup);
 
   useEffect(() => {
+    // フィルターの初期化を先に実行
+    for (const filter of hinatazakaFilters) {
+      useFilterStore.getState().setFilter(filter.type, filter.defaultChecked || false);
+    }
+
     if (allMembers.length === 0) {
       // 初回のみデータロード
       setGroup(selectedGroup);

--- a/view/components/Home/MemberInfo/MemberInfo.tsx
+++ b/view/components/Home/MemberInfo/MemberInfo.tsx
@@ -23,7 +23,8 @@ export function MemberInfo() {
       .filter(([, checked]) => checked)
       .map(([type]) => type);
 
-    if (selected.length > 0) {
+    // フィルターが選択されている場合、または初期状態（フィルターが未設定）の場合にメンバーを選択
+    if (selected.length > 0 || Object.keys(checkedFilters).length === 0) {
       const random = pickRandomMember()
 
       // if (random === undefined) {

--- a/view/next-env.d.ts
+++ b/view/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/view/stores/useSelectedMemberStore.ts
+++ b/view/stores/useSelectedMemberStore.ts
@@ -125,7 +125,10 @@ export const useSelectedMemberStore = create<SelectedMemberStore>((set, get) => 
       get().applyFilters()
       
       // 初回のランダムメンバー選択
-      get().pickRandomMember()
+      // フィルター適用後に確実にメンバーが選択されるよう少し遅延して実行
+      setTimeout(() => {
+        get().pickRandomMember()
+      }, 0)
       
       console.log(`${group}のデータ読み込み完了: ${members.length}件`)
     } catch (error) {
@@ -156,6 +159,17 @@ export const useSelectedMemberStore = create<SelectedMemberStore>((set, get) => 
 
     // フィルター条件の妥当性チェック
     const hasValidFilter = (filters.gen?.length ?? 0) > 0 || filters.graduated !== undefined;
+
+    // フィルターが全く設定されていない場合は、卒業生を除く全メンバーを表示
+    if (!hasValidFilter) {
+      const filteredMembers = allMembers.filter(member => !member.graduated);
+      set({
+        filteredMembers,
+        hasInvalidFilter: false
+      });
+      get().shuffleMembers();
+      return;
+    }
 
     // メンバーのフィルタリング実行
     const filteredMembers = allMembers.filter((member) => {


### PR DESCRIPTION
Ensure members are displayed immediately after data fetch without requiring filter interaction.

Previously, members were not displayed on initial load because the selection logic required explicit filter interaction. This PR corrects the filter initialization order, defines a default display state (all non-graduated members) when no filters are active, and ensures members are selected immediately after data is fetched.

---
[Slack Thread](https://aobaiwaki.slack.com/archives/C09E9911NMQ/p1757915447695439?thread_ts=1757915447.695439&cid=C09E9911NMQ)

<a href="https://cursor.com/background-agent?bcId=bc-c6130c87-c8d3-4c07-9ff5-7e8a764f6586">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6130c87-c8d3-4c07-9ff5-7e8a764f6586">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

