### PR TITLE
Trigger view ci on package json update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'view/**'
+      - 'package.json'
   pull_request:
     branches:
       - main
+    paths:
+      - 'view/**'
+      - 'package.json'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,14 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'view/**'
       - 'package.json'
   pull_request:
     branches:
       - main
+      - dev
     paths:
       - 'view/**'
       - 'package.json'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,6 +9,7 @@ on:
       - reopened
     paths:
       - 'view/**'
+      - 'package.json'
 
 permissions:
   contents: read


### PR DESCRIPTION
Configure CI and Trivy workflows to trigger on changes to `view/` directory or root `package.json`.

This ensures view-related tests and security scans run on relevant dependency updates and optimizes CI execution by limiting triggers.

---
[Slack Thread](https://aobaiwaki.slack.com/archives/C09E9911NMQ/p1758027161304659?thread_ts=1758027161.304659&cid=C09E9911NMQ)

<a href="https://cursor.com/background-agent?bcId=bc-8d53cdac-8354-4f67-8683-d2f540a076fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d53cdac-8354-4f67-8683-d2f540a076fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

