### PR TITLE
Fix github action release note trigger

### DIFF
--- a/.github/scripts/bump.sh
+++ b/.github/scripts/bump.sh
@@ -11,7 +11,14 @@ case "$1" in
     patch) patch="$((patch + 1))" ;;
 esac
 
+# Personal Access Tokenを使用してタグを作成・プッシュ
 git tag "v${major}.${minor}.${patch}"
 git tag --force "v${major}" >/dev/null 2>&1
+
+# Personal Access Tokenを使用してリモートURLを設定
+if [ -n "${GITHUB_TOKEN}" ]; then
+    git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+fi
+
 git push --force --tags >/dev/null 2>&1
 echo "v${major}.${minor}.${patch}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,15 @@ jobs:
             echo "No valid label found. Exiting."
             exit 1
           fi
-      - env:
+      - name: Create and Push Tag
+        env:
           USERNAME: github-actions[bot]
           EMAIL: github-actions[bot]@users.noreply.github.com
           BUMP_LEVEL: ${{ steps.determine-bump.outputs.bump_level }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Personal Access Tokenを使用してタグ作成時に他のワークフローを起動可能にする
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           git config --global user.name "${USERNAME}"
           git config --global user.email "${EMAIL}"
           version="$(.github/scripts/bump.sh "${BUMP_LEVEL}")"
+          echo "Created version: ${version}"

--- a/README.md
+++ b/README.md
@@ -343,6 +343,34 @@ make cd  # 一括実行
 
 ### 認証設定
 
+#### GitHub Actions Personal Access Token (PAT)
+
+GitHub Actionsでのタグ作成時に他のワークフローを起動するため、Personal Access Tokenが必要です。
+
+##### PAT作成手順
+1. GitHub設定 → Developer settings → Personal access tokens → Tokens (classic)
+2. "Generate new token (classic)" をクリック
+3. 以下の権限を選択：
+   - `repo` (Full control of private repositories)
+   - `workflow` (Update GitHub Action workflows)
+4. トークンを生成し、安全な場所に保存
+
+##### リポジトリSecrets設定
+1. GitHubリポジトリ → Settings → Secrets and variables → Actions
+2. "New repository secret" をクリック
+3. Name: `PAT_TOKEN`、Value: 生成したPersonal Access Tokenを入力
+4. "Add secret" で保存
+
+##### 動作確認
+```bash
+# PRマージ後、以下のワークフローが自動実行されることを確認
+# 1. release-action (タグ作成)
+# 2. create-release-note (リリースノート作成)
+# 3. deploy (デプロイメント)
+```
+
+**注意**: `PAT_TOKEN` が設定されていない場合、タグ作成後にリリースノート作成ワークフローが起動しません。
+
 #### gcloud CLI認証
 ```bash
 # ログイン


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Use a Personal Access Token (PAT) for tag creation in the release workflow to enable subsequent workflows like `create-release-note` to trigger.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
GitHub Actions workflows triggered by the default `GITHUB_TOKEN` do not, by design, trigger other workflows. This prevented the `create-release-note` action from running after a tag was pushed by the `release.yml` workflow. By switching to a PAT for tag creation, this limitation is bypassed, allowing the dependent workflow to execute. Instructions for setting up the PAT are included in the README.

---
[Slack Thread](https://aobaiwaki.slack.com/archives/C09E9911NMQ/p1758261148767049?thread_ts=1758261148.767049&cid=C09E9911NMQ)

<a href="https://cursor.com/background-agent?bcId=bc-4cff9092-b14d-4b21-98e4-0852cec2880a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4cff9092-b14d-4b21-98e4-0852cec2880a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

